### PR TITLE
Add workflow_dispatch workflow to submit a game from an HN link

### DIFF
--- a/.github/workflows/submit-from-hn.yml
+++ b/.github/workflows/submit-from-hn.yml
@@ -1,0 +1,26 @@
+name: Submit Game from HN Link
+
+on:
+  workflow_dispatch:
+    inputs:
+      hn-url:
+        description: 'Hacker News thread URL (e.g. https://news.ycombinator.com/item?id=12345678)'
+        required: true
+        type: string
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Create game submission issue
+        run: node scripts/submit-from-hn.mjs "${{ github.event.inputs.hn-url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/submit-from-hn.mjs
+++ b/scripts/submit-from-hn.mjs
@@ -16,7 +16,7 @@ import { createInterface } from "node:readline/promises";
 // CLI args
 // ---------------------------------------------------------------------------
 
-const { values: flags } = parseArgs({
+const { values: flags, positionals } = parseArgs({
   options: {
     "dry-run": { type: "boolean", default: false },
     help: { type: "boolean", short: "h", default: false },
@@ -174,7 +174,12 @@ function createIssue(item) {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const input = await prompt("HN thread URL or ID: ");
+  // Accept URL/ID as positional argument (for non-interactive use, e.g. GitHub Actions)
+  let input = positionals[0] || process.env.HN_URL || "";
+
+  if (!input) {
+    input = await prompt("HN thread URL or ID: ");
+  }
 
   if (!input) {
     console.error("No URL provided.");


### PR DESCRIPTION
- New `.github/workflows/submit-from-hn.yml` with a `workflow_dispatch`
  trigger and a required `hn-url` input, so a maintainer can go to
  Actions → "Submit Game from HN Link" → Run workflow, paste an HN thread
  URL, and have the script create a game-submission issue automatically.
- Updated `scripts/submit-from-hn.mjs` to accept the URL as a positional
  CLI argument (or `HN_URL` env var), falling back to the interactive
  prompt for local use.

https://claude.ai/code/session_013qeEBodiEW4rujNyxFEStJ